### PR TITLE
Fix preview size

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,6 @@ Why `UI` can be treated as a `Feedback` loop:
 
 | Counter | Movies |
 | --- | --- |
-|<img align="left" src="https://github.com/ivanvorobei/CombineFeedback/blob/master/diagrams/counter.gif" width="400"/> | <img align="left" src="https://github.com/ivanvorobei/CombineFeedback/blob/master/diagrams/movies.gif"/> |
+|<img src="https://github.com/ivanvorobei/CombineFeedback/blob/master/diagrams/counter.gif" width="200"/> | <img src="https://github.com/ivanvorobei/CombineFeedback/blob/master/diagrams/movies.gif" width="200"/> |
 
 ##### More examples to come stay tuned 🚀

--- a/README.md
+++ b/README.md
@@ -47,6 +47,6 @@ Why `UI` can be treated as a `Feedback` loop:
 
 | Counter | Movies |
 | --- | --- |
-|<img src="https://github.com/ivanvorobei/CombineFeedback/blob/master/diagrams/counter.gif" width="200"/> | <img src="https://github.com/ivanvorobei/CombineFeedback/blob/master/diagrams/movies.gif" width="200"/> |
+|<img src="https://github.com/ivanvorobei/CombineFeedback/blob/master/diagrams/counter.gif" width="250"/> | <img src="https://github.com/ivanvorobei/CombineFeedback/blob/master/diagrams/movies.gif" width="250"/> |
 
 ##### More examples to come stay tuned 🚀

--- a/README.md
+++ b/README.md
@@ -47,6 +47,6 @@ Why `UI` can be treated as a `Feedback` loop:
 
 | Counter | Movies |
 | --- | --- |
-|![](diagrams/counter.gif) | ![](diagrams/movies.gif) |
+|<img align="left" src="https://github.com/ivanvorobei/CombineFeedback/blob/master/diagrams/counter.gif" width="400"/> | <img align="left" src="https://github.com/ivanvorobei/CombineFeedback/blob/master/diagrams/movies.gif"/> |
 
 ##### More examples to come stay tuned 🚀


### PR DESCRIPTION
Set width to `250` for preview gifs. See screenshoots: 

**Before:**

<img width="500" alt="Screenshot 2019-06-08 at 14 14 54" src="https://user-images.githubusercontent.com/10995774/59146540-df6e8380-89f7-11e9-945c-650d4d0e0380.png">

**After:**

<img width="500" alt="Screenshot 2019-06-08 at 14 14 46" src="https://user-images.githubusercontent.com/10995774/59146538-df6e8380-89f7-11e9-8580-02aac3a12d39.png">