### PR TITLE
Add TestScheduler and fix System so it always emits the initial state

### DIFF
--- a/CombineFeedback.xcodeproj/project.pbxproj
+++ b/CombineFeedback.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		583971C522ADFA1F00139CC0 /* ViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 583971C422ADFA1F00139CC0 /* ViewModel.swift */; };
 		58C6E5E022A9F027005A9685 /* Movies.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58C6E5DF22A9F027005A9685 /* Movies.swift */; };
 		58C6E5E722AB14DB005A9685 /* AsyncImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58C6E5E622AB14DB005A9685 /* AsyncImage.swift */; };
+		74A3948322E0B7E20061CE51 /* TestScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74A3948222E0B7E20061CE51 /* TestScheduler.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -157,6 +158,7 @@
 		58C6E5E322AA3B3B005A9685 /* LICENSE */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
 		58C6E5E622AB14DB005A9685 /* AsyncImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AsyncImage.swift; sourceTree = "<group>"; };
 		742D7D6522B02A7100A97AF3 /* Package.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
+		74A3948222E0B7E20061CE51 /* TestScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TestScheduler.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -271,6 +273,7 @@
 			children = (
 				5800FF9E22A89BE6005A860B /* CombineFeedbackTests.swift */,
 				5800FFA022A89BE6005A860B /* Info.plist */,
+				74A3948222E0B7E20061CE51 /* TestScheduler.swift */,
 			);
 			path = CombineFeedbackTests;
 			sourceTree = "<group>";
@@ -646,6 +649,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				5800FF9F22A89BE6005A860B /* CombineFeedbackTests.swift in Sources */,
+				74A3948322E0B7E20061CE51 /* TestScheduler.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/CombineFeedback.xcodeproj/project.pbxproj
+++ b/CombineFeedback.xcodeproj/project.pbxproj
@@ -38,7 +38,7 @@
 		583971C522ADFA1F00139CC0 /* ViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 583971C422ADFA1F00139CC0 /* ViewModel.swift */; };
 		58C6E5E022A9F027005A9685 /* Movies.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58C6E5DF22A9F027005A9685 /* Movies.swift */; };
 		58C6E5E722AB14DB005A9685 /* AsyncImage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58C6E5E622AB14DB005A9685 /* AsyncImage.swift */; };
-		74A3948322E0B7E20061CE51 /* TestScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74A3948222E0B7E20061CE51 /* TestScheduler.swift */; };
+		7415E15122E1B4F000117DA3 /* TestScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74A3948222E0B7E20061CE51 /* TestScheduler.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -263,6 +263,7 @@
 				5800FFAA22A89C08005A860B /* Feedback.swift */,
 				5800FFAB22A89C08005A860B /* FlatMapLatest.swift */,
 				5800FFAC22A89C08005A860B /* System.swift */,
+				74A3948222E0B7E20061CE51 /* TestScheduler.swift */,
 				5800FF9422A89BE6005A860B /* Info.plist */,
 			);
 			path = CombineFeedback;
@@ -273,7 +274,6 @@
 			children = (
 				5800FF9E22A89BE6005A860B /* CombineFeedbackTests.swift */,
 				5800FFA022A89BE6005A860B /* Info.plist */,
-				74A3948222E0B7E20061CE51 /* TestScheduler.swift */,
 			);
 			path = CombineFeedbackTests;
 			sourceTree = "<group>";
@@ -639,6 +639,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				5800FFAF22A89C09005A860B /* FlatMapLatest.swift in Sources */,
+				7415E15122E1B4F000117DA3 /* TestScheduler.swift in Sources */,
 				5800FFB022A89C09005A860B /* System.swift in Sources */,
 				5800FFAE22A89C09005A860B /* Feedback.swift in Sources */,
 			);
@@ -649,7 +650,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				5800FF9F22A89BE6005A860B /* CombineFeedbackTests.swift in Sources */,
-				74A3948322E0B7E20061CE51 /* TestScheduler.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Sources/CombineFeedback/System.swift
+++ b/Sources/CombineFeedback/System.swift
@@ -19,6 +19,7 @@ extension Publishers {
             return Publishers.MergeMany(events)
                 .receive(on: scheduler)
                 .scan(initial, reduce)
+                .prepend(initial)
                 .handleEvents(receiveOutput: state.send)
                 .receive(on: scheduler)
                 .eraseToAnyPublisher()

--- a/Sources/CombineFeedback/TestScheduler.swift
+++ b/Sources/CombineFeedback/TestScheduler.swift
@@ -1,8 +1,6 @@
 import Foundation
 import Combine
 
-
-
 /// A scheduler that implements virtualized time, for use in testing.
 /// This implementation is *heavily* based on the TestScheduler in
 /// ReactiveSwift: https://github.com/ReactiveCocoa/ReactiveSwift/blob/master/Sources/Scheduler.swift

--- a/Tests/CombineFeedbackTests/TestScheduler.swift
+++ b/Tests/CombineFeedbackTests/TestScheduler.swift
@@ -1,0 +1,139 @@
+import Foundation
+import Combine
+
+
+
+/// A scheduler that implements virtualized time, for use in testing.
+/// This implementation is *heavily* based on the TestScheduler in
+/// ReactiveSwift: https://github.com/ReactiveCocoa/ReactiveSwift/blob/master/Sources/Scheduler.swift
+public class TestScheduler: Scheduler {
+    public typealias SchedulerTimeType = DispatchQueue.SchedulerTimeType
+    public typealias SchedulerOptions = Never
+
+    private final class ScheduledAction {
+        let date: SchedulerTimeType
+        let action: () -> Void
+
+        init(date: SchedulerTimeType, action: @escaping () -> Void) {
+            self.date = date
+            self.action = action
+        }
+
+        func less(_ rhs: ScheduledAction) -> Bool {
+            return date < rhs.date
+        }
+    }
+
+    private let lock = NSRecursiveLock()
+    private var _currentDate: SchedulerTimeType
+    private var scheduledActions: [ScheduledAction] = []
+
+    public var now: SchedulerTimeType {
+        let d: SchedulerTimeType
+
+        lock.lock()
+        d = _currentDate
+        lock.unlock()
+
+        return d
+    }
+
+    public var minimumTolerance: SchedulerTimeType.Stride {
+        return SchedulerTimeType.Stride(.nanoseconds(1))
+    }
+
+    public init() {
+        lock.name = "CombineFeedback.TestScheduler"
+        _currentDate = SchedulerTimeType(DispatchTime.now())
+    }
+
+    private func schedule(_ action: ScheduledAction) -> Void {
+        lock.lock()
+        scheduledActions.append(action)
+        scheduledActions.sort { $0.less($1) }
+        lock.unlock()
+    }
+
+    public func schedule(options: Never?, _ action: @escaping () -> Void) {
+        schedule(ScheduledAction(date: now, action: action))
+    }
+
+    public func schedule(
+        after date: DispatchQueue.SchedulerTimeType,
+        tolerance: DispatchQueue.SchedulerTimeType.Stride,
+        options: Never?,
+        _ action: @escaping () -> Void
+    ) {
+        schedule(ScheduledAction(date: date, action: action))
+    }
+
+    public func schedule(
+        after date: DispatchQueue.SchedulerTimeType,
+        interval: DispatchQueue.SchedulerTimeType.Stride,
+        tolerance: DispatchQueue.SchedulerTimeType.Stride,
+        options: Never?,
+        _ action: @escaping () -> Void
+    ) -> Cancellable {
+        let scheduledAction = ScheduledAction(date: date, action: action)
+        schedule(scheduledAction)
+
+        return AnyCancellable {
+            self.lock.lock()
+            self.scheduledActions = self.scheduledActions.filter { $0 !== scheduledAction }
+            self.lock.unlock()
+        }
+    }
+
+    /// Advances the virtualized clock by an extremely tiny interval, dequeuing
+    /// and executing any actions along the way.
+    ///
+    /// This is intended to be used as a way to execute actions that have been
+    /// scheduled to run as soon as possible.
+    public func advance() {
+        advance(by: .nanoseconds(1))
+    }
+
+    /// Advances the virtualized clock by the given interval, dequeuing and
+    /// executing any actions along the way.
+    ///
+    /// - parameters:
+    ///   - interval: Interval by which the current date will be advanced.
+    public func advance(by interval: DispatchQueue.SchedulerTimeType.Stride) {
+
+        lock.lock()
+        advance(to: now.advanced(by: interval))
+        lock.unlock()
+    }
+
+
+    /// Advances the virtualized clock to the given future date, dequeuing and
+    /// executing any actions up until that point.
+    ///
+    /// - parameters:
+    ///   - newDate: Future date to which the virtual clock will be advanced.
+    public func advance(to newDate: SchedulerTimeType) {
+        lock.lock()
+        assert(now.dispatchTime <= newDate.dispatchTime)
+
+        while scheduledActions.count > 0 {
+            if newDate.dispatchTime < scheduledActions[0].date.dispatchTime {
+                break
+            }
+
+            _currentDate = scheduledActions[0].date
+
+            let scheduledAction = scheduledActions.remove(at: 0)
+            scheduledAction.action()
+        }
+
+        _currentDate = newDate
+
+        lock.unlock()
+    }
+
+    /// Dequeues and executes all scheduled actions, leaving the scheduler's
+    /// date at `DispatchTime.distantFuture`.
+    public func run() {
+        advance(to: SchedulerTimeType(DispatchTime.distantFuture))
+    }
+}


### PR DESCRIPTION
This PR does the following:

* Added `TestScheduler`, heavily influenced by the `TestScheduler` from [ReactiveSwift](https://github.com/ReactiveCocoa/ReactiveSwift/blob/master/Sources/Scheduler.swift)
* Fix `System` so that it always emits the initial state.
* Change tests to use the `TestScheduler`

@sergdort please check this carefully before merging. Particularly the part about adding `.prepend(initial)` in the system.
