### PR TITLE
View.bind(_:, to:) return type is simply `some View`

### DIFF
--- a/Example/Views/AsyncImage.swift
+++ b/Example/Views/AsyncImage.swift
@@ -28,7 +28,7 @@ extension View {
     func bind<P: Publisher, Value>(
         _ publisher: P,
         to state: Binding<Value>
-    ) -> SubscriptionView<P, Self> where P.Failure == Never, P.Output == Value {
+    ) -> some View where P.Failure == Never, P.Output == Value {
         return onReceive(publisher) { value in
             state.value = value
         }

--- a/Sources/CombineFeedbackUI/Widget.swift
+++ b/Sources/CombineFeedbackUI/Widget.swift
@@ -29,7 +29,7 @@ extension View {
     func bind<P: Publisher, Value>(
         _ publisher: P,
         to binding: Binding<Value>
-    ) -> SubscriptionView<P, Self> where P.Failure == Never, P.Output == Value {
+    ) -> some View where P.Failure == Never, P.Output == Value {
         return onReceive(publisher) { value in
             binding.value = value
         }


### PR DESCRIPTION
SwiftUI.onReceive now returns `some View` instead of SubscriptionView which lead to this change