### PR TITLE
add share() in Publishers extension

### DIFF
--- a/Sources/CombineFeedback/System.swift
+++ b/Sources/CombineFeedback/System.swift
@@ -24,6 +24,7 @@ extension Publishers {
                 .receive(on: scheduler)
                 .eraseToAnyPublisher()
         }
+        .share()
         .eraseToAnyPublisher()
     }
 }


### PR DESCRIPTION
fixes an issue where multiple subscriptions would kick off feedbacks multiple times