### PR TITLE
Make publisher public

### DIFF
--- a/Sources/CombineFeedback/Store/Store.swift
+++ b/Sources/CombineFeedback/Store/Store.swift
@@ -9,7 +9,7 @@ open class Store<State, Event> {
     box._current
   }
 
-  var publisher: AnyPublisher<State, Never> {
+  public var publisher: AnyPublisher<State, Never> {
     box.publisher
   }
 


### PR DESCRIPTION
Hi!

I just added `public` access modifier to `Store.publisher` property (similar as `Store.state`). 
This allow to handle state changes in non SwiftUI projects (without adding fake Feedback for send state over CurrentValueSubject or some other hacks).